### PR TITLE
bin: handle false-y args

### DIFF
--- a/bin/check-file.pl
+++ b/bin/check-file.pl
@@ -50,14 +50,14 @@ my $result = { "file"=>$query->{file} };
 # Prep a query to $extractRegexes.
 my $extractRegexesQuery = {};
 
-if ($query->{file}) {
+if (defined $query->{file}) {
   $extractRegexesQuery->{file} = $query->{file};
 }
 else {
   die "Error, no 'file' specified in input\n";
 }
 
-if ($query->{extractRegexes_language}) {
+if (defined $query->{extractRegexes_language}) {
   $extractRegexesQuery->{language} = $query->{extractRegexes_language};
 }
 

--- a/bin/check-regex.pl
+++ b/bin/check-regex.pl
@@ -45,10 +45,10 @@ my $result = {};
 # Prep a query to $detectVuln.
 my $detectVulnQuery = {};
 
-if ($pattern->{regex}) {
+if (defined $pattern->{regex}) {
   $detectVulnQuery->{pattern} = $pattern->{regex};
 }
-elsif ($pattern->{pattern}) {
+elsif (defined $pattern->{pattern}) {
   $detectVulnQuery->{pattern} = $pattern->{pattern};
 }
 else {
@@ -57,13 +57,13 @@ else {
 
 $result->{pattern} = $detectVulnQuery->{pattern};
 
-if ($pattern->{detectVuln_detectors}) {
+if (defined $pattern->{detectVuln_detectors}) {
   $detectVulnQuery->{detectors} = $pattern->{detectVuln_detectors};
 }
-if ($pattern->{detectVuln_timeLimit}) {
+if (defined $pattern->{detectVuln_timeLimit}) {
   $detectVulnQuery->{timeLimit} = $pattern->{detectVuln_timeLimit};
 }
-if ($pattern->{detectVuln_memoryLimit}) {
+if (defined $pattern->{detectVuln_memoryLimit}) {
   $detectVulnQuery->{memoryLimit} = $pattern->{detectVuln_memoryLimit};
 }
 
@@ -79,17 +79,17 @@ $result->{detectReport} = $detectReport;
 # Prep a query to $validateVuln.
 my $validateVulnQuery = {};
 
-if ($pattern->{regex}) {
+if (defined $pattern->{regex}) {
   $validateVulnQuery->{pattern} = $pattern->{regex};
 }
-elsif ($pattern->{pattern}) {
+elsif (defined $pattern->{pattern}) {
   $validateVulnQuery->{pattern} = $pattern->{pattern};
 }
 else {
   die "Error, neither 'regex' nor 'pattern' specified in input\n";
 }
 
-if ($pattern->{validateVuln_language}) {
+if (defined $pattern->{validateVuln_language}) {
   $validateVulnQuery->{language} = $pattern->{validateVuln_language};
 }
 else {
@@ -98,14 +98,14 @@ else {
 
 # $validateVuln requires nPumps and timeLimit.
 # Choose sensible defaults.
-if ($pattern->{validateVuln_nPumps}) {
+if (defined $pattern->{validateVuln_nPumps}) {
   $validateVulnQuery->{nPumps} = $pattern->{validateVuln_nPumps};
 }
 else {
   $validateVulnQuery->{nPumps} = 250000;
 }
 
-if ($pattern->{validateVuln_timeLimit}) {
+if (defined $pattern->{validateVuln_timeLimit}) {
   $validateVulnQuery->{timeLimit} = $pattern->{validateVuln_timeLimit};
 }
 else {

--- a/bin/check-repo.pl
+++ b/bin/check-repo.pl
@@ -49,12 +49,12 @@ my $result = {};
 
 &cmd("rm -rf $repoRoot");
 my $timeoutInSeconds = 60*60*24; # 1 day in seconds, basically forever.
-if ($query->{checkRepo_timeout}) {
+if (defined $query->{checkRepo_timeout}) {
   $timeoutInSeconds = int($query->{checkRepo_timeout});
 }
 my $repoType = &cloneURL($query->{url}, $repoRoot, $timeoutInSeconds);
 
-if ($repoType) {
+if (defined $repoType) {
   $result->{couldClone} = 1;
   $result->{repoType} = $repoType;
 
@@ -125,7 +125,7 @@ sub cloneURL {
                     );
 
   my @typesToTry;
-  if ($query->{checkRepo_type}) {
+  if (defined $query->{checkRepo_type}) {
     if (defined $type2cloner{$query->{checkRepo_type}}) {
       @typesToTry = ($query->{checkRepo_type});
     }

--- a/bin/check-tree.pl
+++ b/bin/check-tree.pl
@@ -52,7 +52,7 @@ chomp @filesToCheck;
 &log("Found " . scalar(@filesToCheck) . " files");
 
 # Did they want to exclude directories?
-if ($query->{excludeDirs}) {
+if (defined $query->{excludeDirs}) {
   for my $excludeDir (@{$query->{excludeDirs}}) {
     @filesToCheck = grep { not m/(^|\/)$excludeDir\// } @filesToCheck;
   }

--- a/bin/test/check-regex/edgecase-1.json
+++ b/bin/test/check-regex/edgecase-1.json
@@ -1,0 +1,1 @@
+{"pattern": "0", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2}


### PR DESCRIPTION
Issue:
This addresses #6.

Problem:
If args were false-y, 'if ($arg)' would incorrectly evaluate to false.
Specific problem was the regex /0/.

Solution:
I changed all of the 'if ($arg)' to 'if (defined $arg)'.

Test:
I added a test case in check-regex for the problematic regex.