### PR TITLE
cache: use letsencrypt cert

### DIFF
--- a/src/cache/.config.json
+++ b/src/cache/.config.json
@@ -8,8 +8,8 @@
 	"serverConfig": {
 		"serverPort": 8000,
 		"serverCredentials": {
-			"key": "VULN_REGEX_DETECTOR_ROOT/src/cache/server/keys/key.pem",
-			"cert": "VULN_REGEX_DETECTOR_ROOT/src/cache/server/keys/cert.pem"
+			"key": "VULN_REGEX_DETECTOR_ROOT/src/cache/server/keys/privkey.pem",
+			"cert": "VULN_REGEX_DETECTOR_ROOT/src/cache/server/keys/fullchain.pem"
 		},
 		"dbConfig": {
 			"dbServer": "127.0.0.1",

--- a/src/cache/client/cli/cache-client.js
+++ b/src/cache/client/cli/cache-client.js
@@ -83,7 +83,6 @@ const postOptions = {
 log(`postOptions:\n${JSON.stringify(postOptions)}`);
 log(`${query.requestType} ${JSON.stringify(REQUEST_TYPE_TO_PATH)}`);
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // self-signed, baby
 const req = https.request(postOptions, (res) => {
 	log(`STATUS: ${res.statusCode}`);
 	log(`HEADERS: ${JSON.stringify(res.headers)}`);

--- a/src/cache/client/npm/vuln-regex-detector-client.js
+++ b/src/cache/client/npm/vuln-regex-detector-client.js
@@ -46,8 +46,6 @@ function checkRegex (regex, config) {
 	let postBuffer = JSON.stringify(postObject);
 	let postHeaders = generatePostHeaders(_config, Buffer.byteLength(postBuffer));
 
-	process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // TODO. This affects global state.
-
 	// Wrapper so we can return a Promise.
 	function promiseResult (options, data) {
 		log(`promiseResult: data ${data}`);
@@ -131,9 +129,8 @@ function checkRegexSync (regex, config) {
 	let postHeaders = generatePostHeaders(_config, Buffer.byteLength(postBuffer));
 	let url = `https://${postHeaders.hostname}:${postHeaders.port}${postHeaders.path}`;
 
-	process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // TODO. This affects global state.
-
 	try {
+		log(`sending syncRequest: url ${url}`);
 		const response = syncRequest(postHeaders.method, url, {
 			headers: postHeaders,
 			body: postBuffer
@@ -145,6 +142,7 @@ function checkRegexSync (regex, config) {
 
 		return result;
 	} catch (e) {
+		log(`syncRequest threw: ${JSON.stringify(e)}`);
 		return RESPONSE_INVALID;
 	}
 }

--- a/src/cache/test/test-cache.pl
+++ b/src/cache/test/test-cache.pl
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 
 use JSON::PP;
+use Net::Domain qw(hostfqdn);
 
 # Globals
 my $PATTERN_VULNERABLE = 'VULNERABLE';
@@ -353,7 +354,8 @@ sub getCacheConfigFileForTesting {
   my $cacheConfig = decode_json(&readFile("file"=>$cacheConfigFile));
 
   # Edit for testing.
-  $cacheConfig->{clientConfig}->{cacheServer} = "127.0.0.1";
+  my $host = hostfqdn;
+  $cacheConfig->{clientConfig}->{cacheServer} = $host; # For letsencrypt cert, use DNS name.
   $cacheConfig->{serverConfig}->{dbConfig}->{dbServer} = "127.0.0.1";
 
   # Put in tmp file.


### PR DESCRIPTION
Problem:
I was using a self-signed certificate.
These are vulnerable to MITM attacks.

Solution:
I got a certificate through letsencrypt. Thanks EFF!
I made various tweaks to client and server code to support a "real"
SSL certificate rather than the self-signed one I had been using.

Issue:
This fixes #17.