### PR TITLE
validate: try multiple exploits for poly vulns

### DIFF
--- a/bin/check-regex.pl
+++ b/bin/check-regex.pl
@@ -207,7 +207,7 @@ sub queryCache {
     "result"   => $PATTERN_UNKNOWN,
   };
 
-  my $cacheClient = "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/cache/client/cache-client.js";
+  my $cacheClient = "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/cache/client/cli/cache-client.js";
   if (not -f $cacheClient) {
     &log("queryCache: Could not find client $cacheClient");
     return $unknownResponse;

--- a/bin/test/check-regex/causeDetectorTimeout-1.json
+++ b/bin/test/check-regex/causeDetectorTimeout-1.json
@@ -1,1 +1,1 @@
-{"pattern": "(a{1,40}){1,40}$", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2}
+{"pattern": "(a{1,40}){1,40}$", "validateVuln_language": "javascript", "detectVuln_timeLimit": 10, "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2, "useCache":0}

--- a/bin/test/check-regex/edgecase-1.json
+++ b/bin/test/check-regex/edgecase-1.json
@@ -1,1 +1,1 @@
-{"pattern": "0", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2}
+{"pattern": "0", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2, "useCache": 0}

--- a/bin/test/check-regex/unsafe-1.json
+++ b/bin/test/check-regex/unsafe-1.json
@@ -1,1 +1,1 @@
-{"pattern": "(a+)+$", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2}
+{"pattern": "(a+)+$", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2, "useCache": 0}

--- a/bin/test/check-regex/unsafe-2.json
+++ b/bin/test/check-regex/unsafe-2.json
@@ -1,0 +1,1 @@
+{"pattern": ".+\\@.+\\..+", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2, "useCache": 0}

--- a/bin/test/check-regex/unsafe-3.json
+++ b/bin/test/check-regex/unsafe-3.json
@@ -1,0 +1,1 @@
+{"pattern": "(a|a)+$", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2, "useCache": 0}

--- a/bin/test/check-regex/unsafe-4.json
+++ b/bin/test/check-regex/unsafe-4.json
@@ -1,0 +1,1 @@
+{"pattern": ".+\\@.+\\..+a.+a.+a.+", "validateVuln_language": "javascript", "validateVuln_nPumps": 100000, "validateVuln_timeLimit": 2, "useCache": 0}


### PR DESCRIPTION
Problem:
The detectors are eager to exploit higher-order
polynomially vulnerable regexes.

In doing so they may overstep and cause a match,
so no backtracking is required.

Example:
See discussion in Weideman:
  https://github.com/NicolaasWeideman/RegexStaticAnalysis/issues/11

Solution:
In such a case the lesser polynomials may still be effective.
validate-vuln.pl now iterates over the proposed list of pumpPairs
and tries pumpPairs 1..$i.
If any time out we have a winner.

Fixes: #40

Test:
- Various tests for check-regex

Misc:
- Also fixes issue in check-regex: wrong path to cache-client