### PR TITLE
cache: Add in ExpirationTime to local caches.

### DIFF
--- a/src/cache/client/npm/README.md
+++ b/src/cache/client/npm/README.md
@@ -59,13 +59,14 @@ The module exports:
  *    },
  *    cache: {
  *      type: cacheTypes.persistent,
- *      [persistentDir]: '/tmp/vuln-regex-detector-client-persistentCache'
+ *      [persistentDir]: '/tmp/vuln-regex-detector-client-persistentCache',
+ *      [expirationTime]: 60 * 60 * 24 * 7 // 7 days in seconds
  *    }
  *  }
  *
  * Config defaults if not provided:
  *   server: indicated in the example. This is a research server at Virginia Tech.
- *   cache: 'persistent' with persistentDir in a subdir of os.tmpdir().
+ *   cache: 'persistent' with persistentDir in a subdir of os.tmpdir() and an expirationTime of 7 days.
  *
  * @returns Promise fulfilled with responses.X or rejected with responses.invalid.
  */
@@ -118,6 +119,7 @@ If you cannot connect to the server or your query is malformed, you'll get the a
 ## Optimizations
 
 This module maintains a persistent local cache stored in `os.tmpdir()` to reduce the number of HTTP queries.
+The length of time that a result will be stored in the cache before another HTTP query is required is governed by the expirationTime parameter.
 
 ## Privacy
 

--- a/src/cache/client/npm/test/test.js
+++ b/src/cache/client/npm/test/test.js
@@ -208,20 +208,8 @@ describe('vulnRegexDetector', () => {
 		describe('cache', () => {
 			const testCacheExpiryPersistentDir = path.join(os.tmpdir(), 'vuln-regex-detector-TEST-cache-expiration-time');
 			afterEach('remove testCacheExpiryPersistentDir to set up a clean state for subsequent tests', () => {
-				let rmdir = (dir) => {
-					for (const file of fs.readdirSync(dir)) {
-						const filePath = path.join(dir, file);
-						const stat = fs.lstatSync(filePath);
-						if (stat.isDirectory()) {
-							rmdir(filePath);
-						} else {
-							fs.unlinkSync(filePath);
-						}
-					}
-					fs.rmdirSync(dir);
-				};
 				try {
-					rmdir(testCacheExpiryPersistentDir);
+					remove.removeSync(testCacheExpiryPersistentDir);
 				} catch (err) {
 					// The only expected error is ENOENT from when the cache directory does not exist
 					if (err.code !== 'ENOENT') throw err;

--- a/src/cache/client/npm/test/test.js
+++ b/src/cache/client/npm/test/test.js
@@ -270,6 +270,26 @@ describe('vulnRegexDetector', () => {
 					const response3 = vulnRegexDetector.testSync(pattern, invalidConfig);
 					assert.ok(response3 === vulnRegexDetector.responses.invalid, `Query succeeded? response ${response3}`);
 				});
+				it('should not return an expired cache value', () => {
+					const pattern = 'abcde'; // TODO perhaps make some temporary cache for all of the tests and clear it each time.
+					// Make sync query to prime local persistent cache, but use negative cache value to ensure expiration.
+					let validConfig = { cache: { type: vulnRegexDetector.cacheTypes.persistent, expirationTime: -1 } };
+					const response1 = vulnRegexDetector.testSync(pattern, validConfig);
+					assert.ok(response1 === vulnRegexDetector.responses.safe, `Error, unexpected response for sync query: ${response1}`);
+
+					let invalidConfig = {
+						server: {
+							hostname: 'no such host',
+							port: 1
+						},
+						cache: {
+							type: vulnRegexDetector.cacheTypes.persistent,
+							expirationTime: -1
+						}
+					};
+					const response2 = vulnRegexDetector.testSync(pattern, invalidConfig);
+					assert.ok(response2 === vulnRegexDetector.responses.invalid, `Query succeeded? response ${response2}. Unless 'no such host' is a valid hostname we must have a cache hit on an expired entry`);
+				});
 			});
 
 			describe('memory', () => {
@@ -291,6 +311,26 @@ describe('vulnRegexDetector', () => {
 					};
 					const response2 = vulnRegexDetector.testSync(pattern, invalidConfig);
 					assert.ok(response2 === vulnRegexDetector.responses.safe, `Query failed: response ${response2}, probably due to my invalid config.server (so cache failed)`);
+				});
+				it('should not return an expired cache value', () => {
+					const pattern = 'abcde'; // TODO perhaps make some temporary cache for all of the tests and clear it each time.
+					// Make sync query to prime local in-memory cache, but use negative cache value to ensure expiration.
+					let validConfig = { cache: { type: vulnRegexDetector.cacheTypes.memory, expirationTime: -1 } };
+					const response1 = vulnRegexDetector.testSync(pattern, validConfig);
+					assert.ok(response1 === vulnRegexDetector.responses.safe, `Error, unexpected response for sync query: ${response1}`);
+
+					let invalidConfig = {
+						server: {
+							hostname: 'no such host',
+							port: 1
+						},
+						cache: {
+							type: vulnRegexDetector.cacheTypes.memory,
+							expirationTime: -1
+						}
+					};
+					const response2 = vulnRegexDetector.testSync(pattern, invalidConfig);
+					assert.ok(response2 === vulnRegexDetector.responses.invalid, `Query succeeded? response ${response2}. Unless 'no such host' is a valid hostname we must have a cache hit on an expired entry`);
 				});
 			});
 		});

--- a/src/cache/client/npm/vuln-regex-detector-client.js
+++ b/src/cache/client/npm/vuln-regex-detector-client.js
@@ -37,6 +37,9 @@ const CACHE_TYPES = {
 	none: 'none'
 };
 
+const CACHE_VERSION = '2'; // Cache updated to version 2 to permit an expiration time on cache entries.
+// This required an invalidation of previous entries that would never expire and not be in the proper format.
+
 /* Cache: memory. */
 
 /* Default config. */
@@ -48,7 +51,7 @@ const defaultServerConfig = {
 const defaultCacheConfig = {
 	type: CACHE_TYPES.persistent,
 	persistentDir: path.join(os.tmpdir(), 'vuln-regex-detector-client-persistentCache'),
-	expirationTime: 60 * 60 * 24 * 7 // 7 days
+	expirationTime: 60 * 60 * 24 * 7 // 7 days in seconds
 };
 
 /**********
@@ -347,14 +350,16 @@ function updateCache (config, pattern, response) {
 	if (!useCache(config)) {
 		return;
 	}
+
 	/* Only cache VULNERABLE|SAFE responses. */
 	if (response !== RESPONSE_VULNERABLE && response !== RESPONSE_SAFE) {
 		return;
 	}
+
 	/* This entry will expire config.expirationTime seconds from now. */
-	let expirationTimeInMilliseconds = 1000 * config.cache.expirationTime;
-	let expiryDate = new Date(Date.now() + expirationTimeInMilliseconds);
-	let wrappedResponse = {
+	const expirationTimeInMilliseconds = 1000 * config.cache.expirationTime;
+	const expiryDate = new Date(Date.now() + expirationTimeInMilliseconds);
+	const wrappedResponse = {
 		response: response,
 		validUntil: expiryDate.toISOString()
 	};
@@ -368,14 +373,14 @@ function checkCache (config, pattern) {
 		return RESPONSE_UNKNOWN;
 	}
 
-	let valueRetrieved = kvGet(config, pattern);
+	const valueRetrieved = kvGet(config, pattern);
 	if (valueRetrieved === RESPONSE_UNKNOWN) {
 		return RESPONSE_UNKNOWN;
 	}
 	/* Check if the cache entry has expired. */
-	let lastValidDate = new Date(valueRetrieved.validUntil);
-	if (Date.now() > lastValidDate) {
-		/* The entry in the cache has expired. */
+	const lastValidDate = new Date(valueRetrieved.validUntil);
+	if (lastValidDate <= Date.now()) {
+		/* The cache entry has expired. */
 		return RESPONSE_UNKNOWN;
 	}
 	return valueRetrieved.response;
@@ -440,7 +445,7 @@ function kvPersistentFname (config, key) {
 	 * Using a hash might give us false reports on collisions, but this is
 	 * exceedingly unlikely in typical use cases (a few hundred regexes tops). */
 	const hash = crypto.createHash('md5').update(key).digest('hex');
-	const fname = path.join(config.cache.persistentDir, `${hash}-v2.json`);
+	const fname = path.join(config.cache.persistentDir, `${hash}-v${CACHE_VERSION}.json`);
 	return fname;
 }
 


### PR DESCRIPTION
Problem:
After a regex has been rescanned #45 the local client will still have the old result cached.
This means a user who had previously received the result will never hit the server again and see the updated case.

Solution:
Add an expiration time to the cached values that will require the server to be queried again once the time in the cache has exceeded this time. This should be configurable based on the needs of the client.

Fixes: #44 