### PR TITLE
Add ReScue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "src/detect/weideman-RegexStaticAnalysis"]
 	path = src/detect/src/detectors/weideman-RegexStaticAnalysis
 	url = https://github.com/NicolaasWeideman/RegexStaticAnalysis
+[submodule "src/detect/src/detectors/shen-ReScue"]
+	path = src/detect/src/detectors/shen-ReScue
+	url = https://github.com/davisjam/ReScue
+	branch = SupportForVRD

--- a/configure
+++ b/configure
@@ -1,7 +1,8 @@
 #!/usr/bin/env perl
 # Env. var params:
 #   SKIP_PKG_DEPS=1    Don't try to install packages (sudo-less)
-#                      (You should install from source and set your PATH appropriately)
+#                      (You should install any needed packages/binaries from
+#                       source and set your PATH appropriately)
 
 use strict;
 use warnings;
@@ -37,8 +38,9 @@ if ($INSTALL_PKG_DEPS) {
   my @miscPackages_ubuntu = ("zip", "unzip", "make", "git");
   my @rxxr2Packages_ubuntu = ("ocaml");
   my @wustholzPackages_ubuntu = ("default-jdk");
+  my @shenPackages_ubuntu = ("maven");
   my @dynamicAnalysisPackages_ubuntu = ("nodejs", "php-cli", "ruby");
-  my @requiredPackages_ubuntu = (@miscPackages_ubuntu, @rxxr2Packages_ubuntu, @wustholzPackages_ubuntu, @dynamicAnalysisPackages_ubuntu);
+  my @requiredPackages_ubuntu = (@miscPackages_ubuntu, @rxxr2Packages_ubuntu, @wustholzPackages_ubuntu, @shenPackages_ubuntu, @dynamicAnalysisPackages_ubuntu);
   
   &log("Installing dependencies");
   &chkcmd("sudo apt-get install -y @requiredPackages_ubuntu");
@@ -101,6 +103,10 @@ sub configureValidators {
   chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/validate/src/rust" or die "Error, chdir failed: $!\n";
   &chkcmd("make");
 
+  # Java
+  &log("Building Java validator");
+  chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/validate/src/java" or die "Error, chdir failed: $!\n";
+  &chkcmd("mvn clean compile");
 
   ## Build validator tests
   chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/validate/test" or die "Error, chdir failed: $!\n";
@@ -198,9 +204,9 @@ sub configureShen {
   chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/detect/src/detectors" or die "Error, chdir failed: $!\n";
 
   my $dir = "shen-ReScue";
-  my $file = "$dir/release/ReScue.jar";
+  my $file = "$dir/target/ReScue-1.0.jar";
 
-  &chkcmd("cd $dir; mvn clean compile; cd -");
+  &chkcmd("cd $dir; mvn clean compile; mvn package; cd -");
   if (not -f $file) {
     die "Error, configuring shen failed: could not find $file\n";
   }

--- a/configure
+++ b/configure
@@ -87,23 +87,28 @@ sub configureDetectors {
   &configureRXXR2();
   &configureWustholz();
   &configureWeideman();
+  &configureShen();
 
   chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}" or die "Error, chdir failed: $!\n";
   return;
 }
 
 sub configureValidators {
-  # Build validators that need it
+  ## Build validators that need it
+
+  # Rust
   &log("Building rust validator");
   chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/validate/src/rust" or die "Error, chdir failed: $!\n";
   &chkcmd("make");
-  chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}" or die "Error, chdir failed: $!\n";
 
-  chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/validate" or die "Error, chdir failed: $!\n";
-  chdir "test" or die "Error, chdir failed: $!\n";
+
+  ## Build validator tests
+  chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/validate/test" or die "Error, chdir failed: $!\n";
   &chkcmd("./gen-tests.pl");
 
+  ## Reset pwd
   chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}" or die "Error, chdir failed: $!\n";
+
   return;
 }
 
@@ -185,6 +190,22 @@ sub configureWeideman {
   }
 
   &log("Configured weideman");
+
+  return;
+}
+
+sub configureShen {
+  chdir "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/detect/src/detectors" or die "Error, chdir failed: $!\n";
+
+  my $dir = "shen-ReScue";
+  my $file = "$dir/release/ReScue.jar";
+
+  &chkcmd("cd $dir; mvn clean compile; cd -");
+  if (not -f $file) {
+    die "Error, configuring shen failed: could not find $file\n";
+  }
+
+  &log("Configured shen");
 
   return;
 }

--- a/src/detect/README.md
+++ b/src/detect/README.md
@@ -49,6 +49,7 @@ These are the detectors we use:
 1. RXXR2 (Rathnayake and Thielecke). [Project homepage](http://www.cs.bham.ac.uk/~hxt/research/rxxr2/index.shtml), [paper](https://arxiv.org/pdf/1405.7058.pdf).
 2. REXPLOITER (Wustholz, Olivo, Heule, and Dillig). [JAR](http://www.wuestholz.com/downloads/regexcheck.zip), [paper](https://arxiv.org/pdf/1701.04045.pdf).
 3. RegexStaticAnalysis (Weideman, van der Merwe, Berglund, and Watson). [Project homepage](https://github.com/NicolaasWeideman/RegexStaticAnalysis), [paper](https://link.springer.com/chapter/10.1007/978-3-319-40946-7_27), [thesis](http://scholar.sun.ac.za/bitstream/handle/10019.1/102879/weideman_static_2017.pdf?sequence=2).
+4. ReScue (Shen, Jiang, Xu, Yu, Ma, and Lu). [Project homepage](https://github.com/2bdenny/ReScue), [paper](http://cs.nju.edu.cn/changxu/1_publications/ASE18.pdf).
 
 # How do I add a new detector?
 

--- a/src/detect/detect-vuln.pl
+++ b/src/detect/detect-vuln.pl
@@ -155,6 +155,7 @@ sub getDetectors {
   my @detectors = ( {"name" => "rathnayake-rxxr2"},
                     {"name" => "weideman-RegexStaticAnalysis"},
                     {"name" => "wuestholz-RegexCheck"},
+                    {"name" => "shen-ReScue"},
                   );
   # field: driver
   for my $d (@detectors) {

--- a/src/detect/src/drivers/query-shen-ReScue.pl
+++ b/src/detect/src/drivers/query-shen-ReScue.pl
@@ -1,0 +1,159 @@
+#!/usr/bin/env perl
+# Author: Jamie Davis <davisjam@vt.edu>
+# Description: Query the shen-ReScue detector for pattern safety
+#
+# Dependencies:
+#   - VULN_REGEX_DETECTOR_ROOT must be defined
+
+use strict;
+use warnings;
+
+use IPC::Cmd qw[can_run]; # Check PATH
+use JSON::PP; # I/O
+use Data::Dumper;
+use Carp;
+
+# Check dependencies.
+if (not defined $ENV{VULN_REGEX_DETECTOR_ROOT}) {
+  die "Error, VULN_REGEX_DETECTOR_ROOT must be defined\n";
+}
+
+my $ReScueDir = "$ENV{VULN_REGEX_DETECTOR_ROOT}/src/detect/src/detectors/shen-ReScue";
+if (not -d $ReScueDir) {
+  die "Error, could not find ReScueDir <$ReScueDir>\n";
+}
+
+if (not can_run("java")) {
+  die "Error, cannot find 'java'\n";
+}
+
+# Check args.
+if (scalar(@ARGV) != 1) {
+  die "Usage: $0 pattern.json\n";
+}
+
+my $patternFile = $ARGV[0];
+if (not -f $patternFile) {
+  die "Error, no such patternFile $patternFile\n";
+}
+
+# Read.
+my $cont = &readFile("file"=>$patternFile);
+my $pattern = decode_json($cont);
+
+my $query = { "regex" => $pattern->{pattern} };
+
+# Write out to a tmp file for ReScue format.
+my $tmpFile = "/tmp/query-shen-ReScue-$$.regex";
+unlink $tmpFile;
+&writeToFile("file"=>$tmpFile, "contents"=>encode_json($query));
+print STDERR "CLEANUP: $tmpFile\n"; # If we time out, the parent can clean up for us.
+
+# Run.
+my $jvmNoDumpFlags = ""; # TODO Is there a portable way to do this? "-XXnoJrDump -XXdumpSize:none"; # Disable crash files (generated if ulimit on memory exceeded).
+my $cmdString = "java $jvmNoDumpFlags -jar $ReScueDir/target/ReScue-1.0.jar --regexFile=$tmpFile";
+my ($rc, $out) = &cmd("$cmdString 2>&1");
+unlink $tmpFile;
+
+# Parse to determine opinion
+my $opinion = { };
+if ($out =~ m/AttackResult: ({.+})\n/) {
+  # AttackResult: {"regex":"(a+)+$","canAnalyze":true,"isSafe":false,"evilInputs":[{"pumpPairs":[{"prefix":"I","pump":"aaaa"}],"suffix":"aaaaaaaaaaaaaaaaav"}]}
+  my $attackResultStr = $1;
+  my $attackResult = decode_json($attackResultStr);
+  $opinion->{canAnalyze} = $attackResult->{canAnalyze};
+  $opinion->{isSafe} = $attackResult->{isSafe};
+  $opinion->{evilInputs} = $attackResult->{evilInputs};
+} else {
+  $opinion->{canAnalyze} = 0;
+  $opinion->{isSafe} = "UNKNOWN";
+  $opinion->{evilInput} = ["COULD-NOT-PARSE"];
+}
+
+&log("\n\n--------------------\n\nOutput:\n$out");
+
+# Update $pattern.
+$pattern->{opinion} = $opinion;
+
+# Emit.
+print STDOUT encode_json($pattern) . "\n";
+
+#####################
+
+# input: ($cmd)
+# output: ($rc, $out)
+sub cmd {
+  my ($cmd) = @_;
+  &log("CMD: $cmd");
+  my $out = `$cmd`;
+  return ($? >> 8, $out);
+}
+
+sub log {
+  my ($msg) = @_;
+  print STDERR "$msg\n";
+}
+
+# input: %args: keys: file contents
+# output: $file
+sub writeToFile {
+  my %args = @_;
+
+	open(my $fh, '>', $args{file});
+	print $fh $args{contents};
+	close $fh;
+
+  return $args{file};
+}
+
+# input: ($exploitString) JSON object
+#   fields: separators[] pumps[] suffix
+#     separators and pumps have the same length
+# output: ($translatedExploitString) hashref
+#   fields: pumpPairs[] suffix
+#     Each pumpPair is an object with keys: prefix pump
+sub translateExploitString {
+  my ($es) = @_;
+
+  if (defined($es->{separators}) and defined($es->{pumps}) and defined($es->{suffix})) {
+    &log("exploitString looks valid");
+  }
+  else {
+    croak("Invalid exploitString: " . Dumper($es));
+  }
+
+  # Convert Weideman's format to something more sensible:
+  #   pumpPairs[]
+  #   suffix
+
+  my @separators = @{$es->{separators}};
+  my @pumps = @{$es->{pumps}};
+  if (scalar(@separators) ne scalar(@pumps)) {
+    croak("Invalid exploitString: " . Dumper($es));
+  }
+
+  my @pumpPairs;
+  for (my $i = 0; $i < scalar(@separators); $i++) {
+    push @pumpPairs, { "prefix" => $separators[$i],
+                       "pump"   => $pumps[$i]
+                     };
+  }
+
+  my $suffix = $es->{suffix};
+
+  return { "pumpPairs" => \@pumpPairs,
+           "suffix"    => $suffix
+         };
+}
+
+# input: %args: keys: file
+# output: $contents
+sub readFile {
+  my %args = @_;
+
+	open(my $FH, '<', $args{file}) or confess "Error, could not read $args{file}: $!";
+	my $contents = do { local $/; <$FH> }; # localizing $? wipes the line separator char, so <> gets it all at once.
+	close $FH;
+
+  return $contents;
+}


### PR DESCRIPTION
Add ReScue to the ensemble.

ReScue is a super-linear regex detector published at ASE 2018 by Shen et al.
It works on a different principle from the existing three: it is dynamic, not static.

The shen-ReScue submodule currently points at my ReScue fork, specifically the branch [here](https://github.com/davisjam/ReScue/tree/SupportForVRD) that adds input/output that matches the vuln-regex-detector spec. Once [ReScue #6](https://github.com/2bdenny/ReScue/pull/6) lands, the submodule should be pointed at the 2bdenny/ReScue mainline to pick up future improvements.

Fixes: #53