### PR TITLE
Handle .jsx files as JavaScript

### DIFF
--- a/src/extract/extract-regexes.pl
+++ b/src/extract/extract-regexes.pl
@@ -116,7 +116,7 @@ sub extension2language {
   my ($ext) = @_;
 
   my $language = $UNKNOWN_LANGUAGE;
-  if (lc $ext eq "js") {
+  if (lc $ext =~ m/^jsx?$/) {
     $language = "javascript";
   }
   elsif (lc $ext eq "py") {


### PR DESCRIPTION
At my work we have a lot of React code and therefore a lot of [JSX](https://reactjs.org/docs/introducing-jsx.html) which can be a vessel for SL regexes too.

This change causes the extraction process to treat `.jsx` files as JavaScript, on the assumption that extracting static regexes should work the same for JSX, and the JSX sugar itself is just ignored.